### PR TITLE
Dependence updates and fixing morphTo nested relation 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
+        "nunomaduro/collision": "^8.1",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/src/Traits/HasNestedAttributesTrait.php
+++ b/src/Traits/HasNestedAttributesTrait.php
@@ -31,6 +31,11 @@ trait HasNestedAttributesTrait
         return $this->acceptNestedAttributesFor;
     }
 
+    public function parentSave(array $options): bool
+    {
+        return parent::save($options);
+    }
+
     public function fill(array $attributes): self
     {
         if (! empty($this->nested)) {
@@ -53,14 +58,10 @@ trait HasNestedAttributesTrait
 
         $this->old_data = $this->getOriginal();
 
-        if (! parent::save($options)) {
-            return false;
-        }
-
         foreach ($this->getAcceptNestedAttributesFor() as $attribute => $stack) {
             $relationName = $this->getRelationNameForAttribute($attribute);
 
-            $this->getPersistable($relationName, $stack)->save();
+            $this->getPersistable($relationName, $stack, $options)->save();
         }
 
         parent::save($options);
@@ -70,7 +71,7 @@ trait HasNestedAttributesTrait
         return true;
     }
 
-    private function getRelationNameForAttribute($attribute)
+    private function getRelationNameForAttribute($attribute): string
     {
         $methodName = (string) str($attribute)->camel();
 
@@ -83,8 +84,9 @@ trait HasNestedAttributesTrait
     }
 
     private function getPersistable(
-        $relationName,
-        $params
+        string $relationName,
+        array $params,
+        array $options
     ): PersistableNestedRelation {
         $relation = $this->{$relationName}();
 
@@ -102,7 +104,8 @@ trait HasNestedAttributesTrait
             $relation,
             $params,
             $this->old_data,
-            $relationName
+            $relationName,
+            $options
         );
     }
 }

--- a/src/Traits/SaveManyNestedRelation.php
+++ b/src/Traits/SaveManyNestedRelation.php
@@ -2,6 +2,7 @@
 
 namespace Cfx\LaravelNestedAttributes\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -9,11 +10,12 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 final class SaveManyNestedRelation extends PersistableNestedRelation
 {
     public function __construct(
-        protected $model,
+        protected Model $model,
         protected Relation $relation,
         protected array $list,
         protected array $old_data,
-        protected string $relationName
+        protected string $relationName,
+        protected array $options,
     ) {
         throw_unless(
             $relation instanceof HasMany || $relation instanceof MorphMany,
@@ -23,6 +25,8 @@ final class SaveManyNestedRelation extends PersistableNestedRelation
 
     public function save(): bool
     {
+        $this->model->parentSave($this->options);
+
         foreach ($this->list as $params) {
             $relationModel = $this->getCurrentRelationModel($params);
 

--- a/src/Traits/SaveMorphToNestedRelation.php
+++ b/src/Traits/SaveMorphToNestedRelation.php
@@ -7,8 +7,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 
-// todo: support "Custom Polymorphic Types"
-// https://laravel.com/docs/9.x/eloquent-relationships#custom-polymorphic-types
 final class SaveMorphToNestedRelation extends PersistableNestedRelation
 {
     public function __construct(

--- a/src/Traits/SaveMorphToNestedRelation.php
+++ b/src/Traits/SaveMorphToNestedRelation.php
@@ -4,6 +4,7 @@ namespace Cfx\LaravelNestedAttributes\Traits;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 
 // todo: support "Custom Polymorphic Types"
@@ -39,14 +40,20 @@ final class SaveMorphToNestedRelation extends PersistableNestedRelation
         $foreignKeyName = $this->relation->getForeignKeyName();
         $morphType = $this->relation->getMorphType();
 
-        $old_morph_class = Arr::get($this->old_data, $morphType);
-        $old_morph_id = Arr::get($this->old_data, $foreignKeyName);
+        $old_morphable_type = $this->model->getRawOriginal($morphType);
+        $old_morphable_id = Arr::get($this->old_data, $foreignKeyName);
 
-        if (! $old_morph_class || ! $old_morph_id) {
+        if (! $old_morphable_type || ! $old_morphable_id) {
             return null;
         }
 
-        return $old_morph_class::find($old_morph_id);
+        $morphable_class = Relation::getMorphedModel($old_morphable_type) ?? $old_morphable_type;
+
+        if (class_exists($morphable_class)) {
+            return $old_morphable_type::find($old_morphable_id);
+        }
+
+        throw "$old_morphable_type is not a valid model class";
     }
 
     private function createNewMorphTo()

--- a/src/Traits/SaveMorphToNestedRelation.php
+++ b/src/Traits/SaveMorphToNestedRelation.php
@@ -2,6 +2,7 @@
 
 namespace Cfx\LaravelNestedAttributes\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Arr;
 
@@ -10,13 +11,13 @@ use Illuminate\Support\Arr;
 final class SaveMorphToNestedRelation extends PersistableNestedRelation
 {
     public function __construct(
-        protected $model,
+        protected Model $model,
         protected MorphTo $relation,
         protected array $params,
         protected array $old_data,
-        protected string $relationName
-    ) {
-    }
+        protected string $relationName,
+        protected array $options
+    ) {}
 
     public function save(): bool
     {
@@ -56,6 +57,8 @@ final class SaveMorphToNestedRelation extends PersistableNestedRelation
 
         $morph = $this->relation->create($data);
         $this->relation->associate($morph);
+
+        $this->model->parentSave($this->options);
 
         return true;
     }

--- a/src/Traits/SaveOneNestedRelation.php
+++ b/src/Traits/SaveOneNestedRelation.php
@@ -2,6 +2,7 @@
 
 namespace Cfx\LaravelNestedAttributes\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -9,11 +10,12 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 final class SaveOneNestedRelation extends PersistableNestedRelation
 {
     public function __construct(
-        protected $model,
+        protected Model $model,
         protected Relation $relation,
         protected array $params,
         protected array $old_data,
-        protected string $relationName
+        protected string $relationName,
+        protected array $options,
     ) {
         throw_unless(
             $relation instanceof HasOne || $relation instanceof MorphOne,
@@ -23,6 +25,8 @@ final class SaveOneNestedRelation extends PersistableNestedRelation
 
     public function save(): bool
     {
+        $this->model->parentSave($this->options);
+
         $relationModel = $this->getCurrentRelationModel();
 
         if ($relationModel === null) {

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,45 @@
 <?php
 
-use Cfx\LaravelNestedAttributes\Tests\TestCase;
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
 
-uses(TestCase::class)->in(__DIR__);
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
At this PR I'm trying to solve the issue of saving morphTo relations
Also solving issue when the morph relation uses "enforceMorphMap" or model cast with "Enum", like:

```
Relation::enforceMorphMap([
    'video' => 'App\Models\Video',
    'scorm' => 'App\Models\Scorm',
    'quiz' => 'App\Models\Quiz',
]);

Or

protected $casts = [
    'contentable_type' => ContentType::class,
];
```

I'm also updating dependence versions to use with Laravel 11